### PR TITLE
fix: Fix copying of bad keyring file to newly-created account

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup-copy-worker.c
+++ b/gnome-initial-setup/gnome-initial-setup-copy-worker.c
@@ -96,7 +96,8 @@ main (int    argc,
   FILE (".config/dconf/user");
   FILE (".config/goa-1.0/accounts.conf");
   FILE (".config/monitors.xml");
-  FILE (".local/share/keyrings/login.keyring");
+  // There seems to be something wrong with this keyring in 19.10
+  // FILE (".local/share/keyrings/login.keyring");
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This seems to fix the login keyring being corrupt on a newly-created account created by initial setup.

Closes #52 