### PR TITLE
Disable theme-switcher again

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup.c
+++ b/gnome-initial-setup/gnome-initial-setup.c
@@ -66,7 +66,7 @@ typedef struct {
 static PageData page_table[] = {
   PAGE (language, FALSE),
   PAGE (keyboard, FALSE),
-  PAGE (appearance, FALSE),
+//  PAGE (appearance, FALSE),
   PAGE (network,  FALSE),
   PAGE (privacy,  FALSE),
   PAGE (timezone, TRUE),


### PR DESCRIPTION
Dconf settings are still not making their way to the user environment