### PR TITLE
summary: Add galp5 for switchable graphics

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -60,6 +60,7 @@ Depends: ${shlibs:Depends},
          ${misc:Depends}
 Recommends: gnome-getting-started-docs,
             gnome-keyring,
+            system76-power,
 Suggests: gdm3
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things

--- a/debian/control.in
+++ b/debian/control.in
@@ -56,6 +56,7 @@ Depends: ${shlibs:Depends},
          ${misc:Depends}
 Recommends: gnome-getting-started-docs,
             gnome-keyring,
+            system76-power,
 Suggests: gdm3
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -379,6 +379,10 @@ gis_summary_page_set_switchable_descriptions (GisSummaryPagePrivate *priv, char 
     right_desc = g_strdup_printf (_("To increase battery life, your %s "
       "defaults to Integrated graphics. To use external displays, switch to NVIDIA "
       "graphics."), product_name);
+  } else if (strcmp (product_version, "galp5") == 0) {
+    // XXX: distinst defaults to integrated due to NVIDIA bug in hybrid mode
+    right_desc = g_strdup_printf (_("Your %s defaults to Integrated graphics. "
+      "To utilize GPU offloading, switch to Hybrid graphics."), product_name);
   } else {
     right_desc = g_strdup_printf (_("Your %s defaults to Hybrid graphics. To launch "
       "an application on the NVIDIA GPU, right click the desktop icon and select "


### PR DESCRIPTION
galp5 has an Intel-only and an NVIDIA variant. Check if either driver is loaded for showing the graphics switching info.